### PR TITLE
refactor(infrastructure): improve OCI Terraform configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used for local dev
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore lock files
+.terraform.lock.hcl
+
+# Ignore any local secrets
+*.pem
+*.key 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,111 @@ kubectl logs -f <pod-name> -n wrappedup-${ENV}
 3. Update the `kustomization.yaml` files to include new resources
 4. Deploy using the scripts
 
+# Terraform Configuration for WrappedUp Kubernetes Infrastructure
+
+This directory contains Terraform configuration files to provision a Kubernetes cluster on Oracle Cloud Infrastructure (OCI) for the WrappedUp application.
+
+## Structure
+
+- `main.tf` - Main configuration file defining all infrastructure resources
+- `variables.tf` - Variable definitions with sensible defaults
+- `providers.tf` - Provider configuration
+- `outputs.tf` - Output definitions that provide useful information after applying
+
+## Prerequisites
+
+1. [Terraform](https://www.terraform.io/downloads.html) (v1.0.0 or higher)
+2. [OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm) configured
+3. [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) (optional, for accessing the cluster)
+
+## Authentication
+
+The configuration uses the OCI provider which can be authenticated in several ways:
+
+1. Environment variables:
+   ```
+   export OCI_TENANCY_OCID="ocid1.tenancy.oc1..xxx"
+   export OCI_USER_OCID="ocid1.user.oc1..xxx"
+   export OCI_FINGERPRINT="xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+   export OCI_PRIVATE_KEY_PATH="/path/to/oci_api_key.pem"
+   export OCI_REGION="eu-madrid-1"
+   ```
+
+2. Using the OCI configuration file (`~/.oci/config`)
+
+## Usage
+
+1. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+
+2. Review the infrastructure plan:
+   ```bash
+   terraform plan
+   ```
+
+3. Apply the configuration:
+   ```bash
+   terraform apply
+   ```
+
+4. After successful application, get the kubeconfig:
+   ```bash
+   $(terraform output -raw kubeconfig_command)
+   ```
+
+## Customization
+
+You can customize the infrastructure by modifying the variables in a `terraform.tfvars` file:
+
+```hcl
+region             = "eu-madrid-1"
+compartment_id     = "ocid1.tenancy.oc1..xxx"
+cluster_name       = "WrappedUp-Production"
+kubernetes_version = "v1.32.1"
+node_pool_size     = 3
+node_ocpus         = 4
+node_memory_in_gbs = 16
+```
+
+## Clean Up
+
+To destroy the infrastructure:
+
+```bash
+terraform destroy
+```
+
+## Variables
+
+| Name | Description | Default |
+|------|-------------|---------|
+| `compartment_id` | OCI Compartment ID | *current value* |
+| `region` | OCI Region | eu-madrid-1 |
+| `cluster_name` | Name of the Kubernetes cluster | Wrappedup-Free-Cluster |
+| `kubernetes_version` | Kubernetes version | v1.32.1 |
+| `vcn_cidr` | CIDR block for the VCN | 10.0.0.0/16 |
+| `node_subnet_cidr` | CIDR for the node subnet | 10.0.10.0/24 |
+| `lb_subnet_cidr` | CIDR for the load balancer subnet | 10.0.20.0/24 |
+| `api_endpoint_subnet_cidr` | CIDR for the Kubernetes API endpoint subnet | 10.0.0.0/28 |
+| `node_pool_size` | Number of nodes in the node pool | 2 |
+| `node_shape` | Shape of nodes | VM.Standard.A1.Flex |
+| `node_ocpus` | Number of OCPUs for each node | 2 |
+| `node_memory_in_gbs` | Amount of memory for each node in GB | 12 |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `cluster_id` | The OCID of the created OKE cluster |
+| `vcn_id` | The OCID of the VCN |
+| `node_pool_id` | The OCID of the node pool |
+| `lb_subnet_id` | The OCID of the load balancer subnet |
+| `kubeconfig_command` | Command to generate kubeconfig file for the cluster | 
+
 ## Future Improvements
 
-- [ ] Add Terraform configurations for infrastructure provisioning
 - [ ] Implement automated testing for Kubernetes configurations
 - [ ] Add monitoring and alerting setup
 - [ ] Implement backup and disaster recovery procedures 

--- a/terraform/OracleCloud/main.tf
+++ b/terraform/OracleCloud/main.tf
@@ -1,0 +1,355 @@
+locals {
+	common_tags = merge(var.tags, {
+		"OKEclusterName" = var.cluster_name
+	})
+}
+
+resource "oci_core_vcn" "oke_vcn" {
+	cidr_block = var.vcn_cidr
+	compartment_id = var.compartment_id
+	display_name = "oke-vcn-${var.cluster_name}"
+	dns_label = replace(var.cluster_name, "-", "")
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_internet_gateway" "oke_igw" {
+	compartment_id = var.compartment_id
+	display_name = "oke-igw-${var.cluster_name}"
+	enabled = true
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_nat_gateway" "oke_ngw" {
+	compartment_id = var.compartment_id
+	display_name = "oke-ngw-${var.cluster_name}"
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_service_gateway" "oke_sgw" {
+	compartment_id = var.compartment_id
+	display_name = "oke-sgw-${var.cluster_name}"
+	services {
+		service_id = "ocid1.service.oc1.eu-madrid-1.aaaaaaaafxkoaua7i6vpniplhcnme6lgi3tymk65mbltlxqfvsxpsdqhzf5a"
+	}
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_route_table" "private_route_table" {
+	compartment_id = var.compartment_id
+	display_name = "oke-private-routetable-${var.cluster_name}"
+	route_rules {
+		description = "traffic to the internet"
+		destination = "0.0.0.0/0"
+		destination_type = "CIDR_BLOCK"
+		network_entity_id = "${oci_core_nat_gateway.oke_ngw.id}"
+	}
+	route_rules {
+		description = "traffic to OCI services"
+		destination = var.service_cidr_block
+		destination_type = "SERVICE_CIDR_BLOCK"
+		network_entity_id = "${oci_core_service_gateway.oke_sgw.id}"
+	}
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_subnet" "service_lb_subnet" {
+	cidr_block = var.lb_subnet_cidr
+	compartment_id = var.compartment_id
+	display_name = "oke-svclbsubnet-${var.cluster_name}"
+	dns_label = "lbsub${random_string.lb_subnet_dns_label.result}"
+	prohibit_public_ip_on_vnic = false
+	route_table_id = "${oci_core_default_route_table.public_route_table.id}"
+	security_list_ids = ["${oci_core_vcn.oke_vcn.default_security_list_id}"]
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_subnet" "node_subnet" {
+	cidr_block = var.node_subnet_cidr
+	compartment_id = var.compartment_id
+	display_name = "oke-nodesubnet-${var.cluster_name}"
+	dns_label = "sub${random_string.node_subnet_dns_label.result}"
+	prohibit_public_ip_on_vnic = true
+	route_table_id = "${oci_core_route_table.private_route_table.id}"
+	security_list_ids = ["${oci_core_security_list.node_sec_list.id}"]
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_subnet" "kubernetes_api_endpoint_subnet" {
+	cidr_block = var.api_endpoint_subnet_cidr
+	compartment_id = var.compartment_id
+	display_name = "oke-k8sApiEndpoint-subnet-${var.cluster_name}"
+	dns_label = "sub${random_string.api_subnet_dns_label.result}"
+	prohibit_public_ip_on_vnic = false
+	route_table_id = "${oci_core_default_route_table.public_route_table.id}"
+	security_list_ids = ["${oci_core_security_list.kubernetes_api_endpoint_sec_list.id}"]
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_default_route_table" "public_route_table" {
+	display_name = "oke-public-routetable-${var.cluster_name}"
+	route_rules {
+		description = "traffic to/from internet"
+		destination = "0.0.0.0/0"
+		destination_type = "CIDR_BLOCK"
+		network_entity_id = "${oci_core_internet_gateway.oke_igw.id}"
+	}
+	manage_default_resource_id = "${oci_core_vcn.oke_vcn.default_route_table_id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_security_list" "service_lb_sec_list" {
+	compartment_id = var.compartment_id
+	display_name = "oke-svclbseclist-${var.cluster_name}"
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_security_list" "node_sec_list" {
+	compartment_id = var.compartment_id
+	display_name = "oke-nodeseclist-${var.cluster_name}"
+	egress_security_rules {
+		description = "Allow pods on one worker node to communicate with pods on other worker nodes"
+		destination = var.node_subnet_cidr
+		destination_type = "CIDR_BLOCK"
+		protocol = "all"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "Access to Kubernetes API Endpoint"
+		destination = var.api_endpoint_subnet_cidr
+		destination_type = "CIDR_BLOCK"
+		protocol = "6"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "Kubernetes worker to control plane communication"
+		destination = var.api_endpoint_subnet_cidr
+		destination_type = "CIDR_BLOCK"
+		protocol = "6"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "Path discovery"
+		destination = var.api_endpoint_subnet_cidr
+		destination_type = "CIDR_BLOCK"
+		icmp_options {
+			code = "4"
+			type = "3"
+		}
+		protocol = "1"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "Allow nodes to communicate with OKE to ensure correct start-up and continued functioning"
+		destination = var.service_cidr_block
+		destination_type = "SERVICE_CIDR_BLOCK"
+		protocol = "6"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "ICMP Access from Kubernetes Control Plane"
+		destination = "0.0.0.0/0"
+		destination_type = "CIDR_BLOCK"
+		icmp_options {
+			code = "4"
+			type = "3"
+		}
+		protocol = "1"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "Worker Nodes access to Internet"
+		destination = "0.0.0.0/0"
+		destination_type = "CIDR_BLOCK"
+		protocol = "all"
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "Allow pods on one worker node to communicate with pods on other worker nodes"
+		protocol = "all"
+		source = var.node_subnet_cidr
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "Path discovery"
+		icmp_options {
+			code = "4"
+			type = "3"
+		}
+		protocol = "1"
+		source = var.api_endpoint_subnet_cidr
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "TCP access from Kubernetes Control Plane"
+		protocol = "6"
+		source = var.api_endpoint_subnet_cidr
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "Inbound SSH traffic to worker nodes"
+		protocol = "6"
+		source = "0.0.0.0/0"
+		stateless = false
+	}
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_core_security_list" "kubernetes_api_endpoint_sec_list" {
+	compartment_id = var.compartment_id
+	display_name = "oke-k8sApiEndpoint-${var.cluster_name}"
+	egress_security_rules {
+		description = "Allow Kubernetes Control Plane to communicate with OKE"
+		destination = var.service_cidr_block
+		destination_type = "SERVICE_CIDR_BLOCK"
+		protocol = "6"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "All traffic to worker nodes"
+		destination = var.node_subnet_cidr
+		destination_type = "CIDR_BLOCK"
+		protocol = "6"
+		stateless = false
+	}
+	egress_security_rules {
+		description = "Path discovery"
+		destination = var.node_subnet_cidr
+		destination_type = "CIDR_BLOCK"
+		icmp_options {
+			code = "4"
+			type = "3"
+		}
+		protocol = "1"
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "External access to Kubernetes API endpoint"
+		protocol = "6"
+		source = "0.0.0.0/0"
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "Kubernetes worker to Kubernetes API endpoint communication"
+		protocol = "6"
+		source = var.node_subnet_cidr
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "Kubernetes worker to control plane communication"
+		protocol = "6"
+		source = var.node_subnet_cidr
+		stateless = false
+	}
+	ingress_security_rules {
+		description = "Path discovery"
+		icmp_options {
+			code = "4"
+			type = "3"
+		}
+		protocol = "1"
+		source = var.node_subnet_cidr
+		stateless = false
+	}
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+	freeform_tags = local.common_tags
+}
+
+resource "oci_containerengine_cluster" "oke_cluster" {
+	cluster_pod_network_options {
+		cni_type = "OCI_VCN_IP_NATIVE"
+	}
+	compartment_id = var.compartment_id
+	endpoint_config {
+		is_public_ip_enabled = true
+		subnet_id = "${oci_core_subnet.kubernetes_api_endpoint_subnet.id}"
+	}
+	freeform_tags = local.common_tags
+	kubernetes_version = var.kubernetes_version
+	name = var.cluster_name
+	options {
+		admission_controller_options {
+			is_pod_security_policy_enabled = false
+		}
+		persistent_volume_config {
+			freeform_tags = local.common_tags
+		}
+		service_lb_config {
+			freeform_tags = local.common_tags
+		}
+		service_lb_subnet_ids = ["${oci_core_subnet.service_lb_subnet.id}"]
+	}
+	type = "BASIC_CLUSTER"
+	vcn_id = "${oci_core_vcn.oke_vcn.id}"
+}
+
+resource "oci_containerengine_node_pool" "oke_node_pool" {
+	cluster_id = "${oci_containerengine_cluster.oke_cluster.id}"
+	compartment_id = var.compartment_id
+	freeform_tags = merge(local.common_tags, {
+		"OKEnodePoolName" = "pool1"
+	})
+	initial_node_labels {
+		key = "name"
+		value = var.cluster_name
+	}
+	kubernetes_version = var.kubernetes_version
+	name = "pool1"
+	node_config_details {
+		freeform_tags = merge(local.common_tags, {
+			"OKEnodePoolName" = "pool1"
+		})
+		node_pool_pod_network_option_details {
+			cni_type = "OCI_VCN_IP_NATIVE"
+		}
+		placement_configs {
+			availability_domain = var.availability_domain
+			subnet_id = "${oci_core_subnet.node_subnet.id}"
+		}
+		size = var.node_pool_size
+	}
+	node_eviction_node_pool_settings {
+		eviction_grace_duration = "PT60M"
+	}
+	node_shape = var.node_shape
+	node_shape_config {
+		memory_in_gbs = var.node_memory_in_gbs
+		ocpus = var.node_ocpus
+	}
+	node_source_details {
+		image_id = var.node_image_id
+		source_type = "IMAGE"
+	}
+}
+
+resource "random_string" "lb_subnet_dns_label" {
+	length = 8
+	special = false
+	lower = true
+	upper = false
+	numeric = true
+}
+
+resource "random_string" "node_subnet_dns_label" {
+	length = 8
+	special = false
+	lower = true
+	upper = false
+	numeric = true
+}
+
+resource "random_string" "api_subnet_dns_label" {
+	length = 8
+	special = false
+	lower = true
+	upper = false
+	numeric = true
+}

--- a/terraform/OracleCloud/outputs.tf
+++ b/terraform/OracleCloud/outputs.tf
@@ -1,0 +1,24 @@
+output "cluster_id" {
+  description = "The OCID of the created OKE cluster"
+  value       = oci_containerengine_cluster.oke_cluster.id
+}
+
+output "vcn_id" {
+  description = "The OCID of the VCN"
+  value       = oci_core_vcn.oke_vcn.id
+}
+
+output "node_pool_id" {
+  description = "The OCID of the node pool"
+  value       = oci_containerengine_node_pool.oke_node_pool.id
+}
+
+output "lb_subnet_id" {
+  description = "The OCID of the load balancer subnet"
+  value       = oci_core_subnet.service_lb_subnet.id
+}
+
+output "kubeconfig_command" {
+  description = "Command to generate kubeconfig file for the cluster"
+  value       = "oci ce cluster create-kubeconfig --cluster-id ${oci_containerengine_cluster.oke_cluster.id} --file $HOME/.kube/config --region ${var.region} --token-version 2.0.0"
+} 

--- a/terraform/OracleCloud/providers.tf
+++ b/terraform/OracleCloud/providers.tf
@@ -1,0 +1,16 @@
+provider "oci" {
+  region = var.region
+  # Authentication can be configured through environment variables:
+  # OCI_TENANCY_OCID, OCI_USER_OCID, OCI_FINGERPRINT, OCI_PRIVATE_KEY_PATH, OCI_REGION
+  # Or through ~/.oci/config file
+}
+
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 4.0.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+} 

--- a/terraform/OracleCloud/variables.tf
+++ b/terraform/OracleCloud/variables.tf
@@ -1,0 +1,99 @@
+variable "compartment_id" {
+  description = "The OCID of the compartment where resources will be created"
+  type        = string
+  default     = "ocid1.tenancy.oc1..aaaaaaaadov6zouscdscxo3e4yvzqv46jcpdd5ealjwy4xkzst5n3ruetd6a"
+}
+
+variable "region" {
+  description = "The OCI region where resources will be created"
+  type        = string
+  default     = "eu-madrid-1"
+}
+
+variable "cluster_name" {
+  description = "Name of the OKE cluster"
+  type        = string
+  default     = "Wrappedup-Free-Cluster"
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the cluster"
+  type        = string
+  default     = "v1.32.1"
+}
+
+variable "vcn_cidr" {
+  description = "CIDR block for the VCN"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "node_subnet_cidr" {
+  description = "CIDR block for the node subnet"
+  type        = string
+  default     = "10.0.10.0/24"
+}
+
+variable "lb_subnet_cidr" {
+  description = "CIDR block for the load balancer subnet"
+  type        = string
+  default     = "10.0.20.0/24"
+}
+
+variable "api_endpoint_subnet_cidr" {
+  description = "CIDR block for the Kubernetes API endpoint subnet"
+  type        = string
+  default     = "10.0.0.0/28"
+}
+
+variable "node_pool_size" {
+  description = "Number of nodes in the node pool"
+  type        = number
+  default     = 2
+}
+
+variable "node_shape" {
+  description = "Shape of the nodes"
+  type        = string
+  default     = "VM.Standard.A1.Flex"
+}
+
+variable "node_ocpus" {
+  description = "Number of OCPUs for each node"
+  type        = number
+  default     = 2
+}
+
+variable "node_memory_in_gbs" {
+  description = "Amount of memory for each node in GB"
+  type        = number
+  default     = 12
+}
+
+variable "availability_domain" {
+  description = "Availability domain for the node pool"
+  type        = string
+  default     = "QTaI:EU-MADRID-1-AD-1"
+}
+
+variable "node_image_id" {
+  description = "OCID of the node image"
+  type        = string
+  default     = "ocid1.image.oc1.eu-madrid-1.aaaaaaaaqwrcpirbdjbl2vq7m553x5bq63u5dijtbzkn3pekxz7p2iyx4s6a"
+}
+
+variable "service_cidr_block" {
+  description = "Service CIDR block for OCI services"
+  type        = string
+  default     = "all-mad-services-in-oracle-services-network"
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {
+    "ManagedBy"   = "Terraform"
+    "Project"     = "WrappedUp"
+    "Environment" = "Production"
+  }
+} 


### PR DESCRIPTION
- Create structured Terraform setup in OracleCloud directory
- Convert hardcoded values to variables for better maintainability
- Implement resource naming convention with descriptive identifiers
- Add DNS label generation with random strings for uniqueness
- Apply consistent tagging across resources
- Create comprehensive documentation with README
- Add appropriate gitignore for Terraform files
- Create proper provider configuration with version constraints
- Extract useful output values for ease of access
- Fix duplicate provider declaration

This refactoring improves maintainability, portability, and follows Terraform best practices for OCI infrastructure management.